### PR TITLE
Integrate login and create account between db, backend and frontend

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
 			"dependencies": {
 				"cors": "2.8.5",
 				"express": "4.18.2",
+				"funtypes": "5.1.0",
 				"jsonwebtoken": "9.0.2",
 				"mariadb": "3.2.3",
 				"uuid": "9.0.1"
@@ -423,6 +424,11 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/funtypes": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/funtypes/-/funtypes-5.1.0.tgz",
+			"integrity": "sha512-Dg5o5JurgX53F/mTwYnFvV2Y95VZLuXw9emaAGSHnssoWxHciO0ZPwY9TPl2aSqU/LfYfCUHPfw7+1pRZvmqdw=="
 		},
 		"node_modules/get-intrinsic": {
 			"version": "1.2.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,7 @@
 	"dependencies": {
 		"cors": "2.8.5",
 		"express": "4.18.2",
+		"funtypes": "5.1.0",
 		"jsonwebtoken": "9.0.2",
 		"mariadb": "3.2.3",
 		"uuid": "9.0.1"

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,8 +1,9 @@
 // src/app.ts
 import express from 'express'
-import { getAccountInformationAndJwtTokenIfAvailable, createDatabasePool, createAccount } from './mariadb'
+import { login, createDatabasePool, createAccount, verifyVantaaFmToken } from './mariadb'
 import cors from 'cors'
 import { getPasswordSecondHashWithSalt } from './utils'
+import { verify } from 'jsonwebtoken'
 
 const app = express()
 app.use(cors())
@@ -11,7 +12,7 @@ const port = 3000
 const mariaDbPool = createDatabasePool()
 
 app.get('/', (req, res) => {
-	res.send('Hello, TypeScript!')
+	res.send('VantaaFM backend server!')
 })
 
 app.post('/auth/login', async (req, res) => {
@@ -19,18 +20,10 @@ app.post('/auth/login', async (req, res) => {
 	try {
 		const user = req.body
 		const { accountName, passwordHash } = user
-		const info = await getAccountInformationAndJwtTokenIfAvailable(mariaDbPool, accountName, getPasswordSecondHashWithSalt(passwordHash))
-		if (info === undefined) {
-			console.log('user failed to login:', accountName)
-			return res.status(400).json({ status: 400, message: 'Failed to login' })
-		}
-		console.log('user logged in:', accountName)
-		res.status(200).json({
-			status: 200,
-			success: true,
-			message: "login success",
-			data: info,
-		})
+		const loginData = await login(mariaDbPool, accountName, getPasswordSecondHashWithSalt(passwordHash))
+		if (loginData.success) console.log('User logged in:', accountName)
+		else console.log('Failed to log in user: ', accountName)
+		res.status(loginData.status).json(loginData)
 	} catch(error) {
 		console.error(error)
 		return res.status(400).json({ status: 400, message: 'Failed to login' })
@@ -42,21 +35,25 @@ app.post('/auth/createAccount', async (req, res) => {
 	try {
 		const user = req.body
 		const { accountName, passwordHash } = user
-		const success = await createAccount(mariaDbPool, accountName, getPasswordSecondHashWithSalt(passwordHash))
-		if (success === false) {
-			console.log('Failed to create account for user: ', accountName)
-			return res.status(400).json({ status: 400, message: 'Failed to create account' })
-		}
-		console.log('Created account for user:', accountName)
-		res.status(200).json({
-			status: 200,
-			success: true,
-			message: "account created succesfully",
-			data: accountName,
-		})
+		const createAccountData = await createAccount(mariaDbPool, accountName, getPasswordSecondHashWithSalt(passwordHash))
+		if (createAccountData.success) console.log('Created account for user:', accountName)
+		else console.log('Failed to create account for user: ', accountName)
+		res.status(createAccountData.status).json(createAccountData)
 	} catch(error) {
 		console.error(error)
 		return res.status(400).json({ status: 400, message: 'Failed to create account' })
+	}
+})
+
+app.post('/auth/testToken', async (req, res) => {
+	console.log('/auth/testToken')
+	try {
+		const token = req.body
+		const { vantaaFMLoginToken } = token
+		verifyVantaaFmToken(vantaaFMLoginToken)
+	} catch(error) {
+		console.error(error)
+		return res.status(400).json({ status: 400, message: 'Failed to test jwt token' })
 	}
 })
 

--- a/backend/src/mariadb.ts
+++ b/backend/src/mariadb.ts
@@ -1,58 +1,133 @@
 import * as mariaDb from 'mariadb'
-import { sign } from 'jsonwebtoken'
+import { sign, verify } from 'jsonwebtoken'
 import {v4 as uuidv4} from 'uuid'
+import * as funtypes from 'funtypes'
+import { CreateAccountMessage, LoginMessage } from './types/networkingTypes'
 export const createDatabasePool = () => {
 	//todo, parse env variables!
 	return mariaDb.createPool({ host: process.env.DB_HOST, port: Number(process.env.DB_PORT), user: process.env.DB_USER, connectionLimit: 5, password: process.env.DB_PASSWORD, database: process.env.DB_DATABASE })
 }
 
-type AccountInfomation = {
-	userId: string,
-	spotifyToken: string | undefined,
-}
-
 const JWT_TOKEN_PRIVATE_KEY = process.env.JWT_TOKEN_PRIVATE_KEY
 
-export const getAccountInformationAndJwtTokenIfAvailable = async (pool: mariaDb.Pool, accountName: string, passwordHash: string): Promise<AccountInfomation & { jwtToken: string } | undefined> => {
+export type JWTSignableData = funtypes.Static<typeof JWTSignableData>
+export const JWTSignableData = funtypes.ReadonlyObject({ userId: funtypes.String, accountName: funtypes.String })
+
+export const login = async (pool: mariaDb.Pool, accountName: string, passwordHash: string): Promise<LoginMessage> => {
 	if (JWT_TOKEN_PRIVATE_KEY === undefined) throw new Error('JWT_TOKEN_PRIVATE_KEY environment variable missing!')
 	let conn
 	try {
 		conn = await pool.getConnection()
-		const rows = await conn.query<AccountInfomation[]>(`
+		const rows = await conn.query<{userId: string, accountName: string }[]>(`
+			SELECT
+				auth.userId as userId,
+				auth.accountName as accountName
+			from UserAuth auth
+			where
+				accountName = (?) and
+				passwordHash = (?)
+			limit 1
+		`, [accountName, passwordHash])
+		if (rows.length !== 1) return {
+			status: 400,
+			success: false,
+			message: 'Failed to login',
+			data: { accountName },
+		}
+		const accountInformation = rows[0]
+		const jwtToken = sign({ userId: accountInformation.userId, accountName }, JWT_TOKEN_PRIVATE_KEY, { expiresIn: "1d" })
+		return {
+			status: 200,
+			success: true,
+			message: 'Login success',
+			data: { ...accountInformation, vantaaFMLoginToken: jwtToken },
+		}
+	} catch(e) {
+		console.error(e)
+		return {
+			status: 400,
+			success: false,
+			message: 'Encountered an error on login',
+			error: 'Server Error',
+		}
+	} finally {
+		if (conn) conn.release()
+	}
+}
+
+export const createAccount = async (pool: mariaDb.Pool, accountName: string, passwordhash: string): Promise<CreateAccountMessage> => {
+	let conn
+	try {
+		conn = await pool.getConnection()
+		const res = await conn.query("INSERT INTO UserAuth (userId, passwordHash, accountName) VALUES (?, ?, ?)", [uuidv4(), passwordhash, accountName])
+		console.log(res)
+		const loginInformation = await login(pool, accountName, passwordhash)
+		if (loginInformation.success === false) {
+			return {
+				status: 400,
+				success: false,
+				message: "Encountered an error on create account",
+				error: 'Failed to login with created account',
+			}
+		}
+		return {
+			status: 200,
+			success: true,
+			message: "Account created succesfully",
+			data: loginInformation.data,
+		}
+	} catch(e) {
+		console.error(e)
+		return {
+			status: 400,
+			success: false,
+			message: "Encountered an error on create account",
+			error: 'Server Error',
+		}
+	} finally {
+		if (conn) conn.release()
+	}
+}
+
+export const verifyVantaaFmToken = (token: string) => {
+	if (JWT_TOKEN_PRIVATE_KEY === undefined) throw new Error('JWT_TOKEN_PRIVATE_KEY environment variable missing!')
+	const verification = JWTSignableData.parse(verify(token, JWT_TOKEN_PRIVATE_KEY))
+	console.log('verifyVantaaFmToken')
+	console.log(verification)
+}
+
+export const setSpotifyToken = async (pool: mariaDb.Pool, userId: string, spotifyToken: string) => {
+	let conn
+	try {
+		conn = await pool.getConnection()
+		const res = await conn.query("INSERT INTO SpotifyToken (userId, spotifyToken) VALUES (?, ?) ON DUPLICATE KEY UPDATE", [userId, spotifyToken])
+		console.log(res)
+	} catch(e) {
+		console.error(e)
+	} finally {
+		if (conn) conn.release()
+	}
+}
+
+export const getSpotifyToken = async (pool: mariaDb.Pool, userId: string) => {
+	let conn
+	try {
+		conn = await pool.getConnection()
+		const rows = await conn.query<{userId: string, spotifyToken: string }[]>(`
 			SELECT
 				auth.userId as userId,
 				spotify.spotifyToken as spotifyToken
 			from UserAuth auth
 			left join SpotifyToken spotify on (auth.userId = spotify.userId)
 			where
-				accountName = (?) and
-				passwordHash = (?)
+				userId = (?)
 			limit 1
-		`, [accountName, passwordHash])
-		if (rows.length !== 1) return undefined
-		const accountInformation = rows[0]
-		const jwtToken = sign({ _id: accountInformation.userId, accountName: accountName }, JWT_TOKEN_PRIVATE_KEY, { expiresIn: "1d" })
-		return { ...accountInformation, jwtToken }
+		`, [userId])
+		if (rows.length !== 1) throw Error('Did not get any rows')
+		console.log(rows)
 	} catch(e) {
 		console.error(e)
 	} finally {
-		if (conn) conn.release() //release to pool
+		if (conn) conn.release()
 	}
-	return undefined
-}
-
-export const createAccount = async (pool: mariaDb.Pool, accountName: string, passwordhash: string) => {
-	let conn
-	try {
-		conn = await pool.getConnection()
-		const res = await conn.query("INSERT INTO UserAuth (userId, passwordHash, accountName) VALUES (?, ?, ?)", [uuidv4(), passwordhash, accountName])
-		//todo, look what this returns and see if its successfull o not
-		console.log(res)
-		return true
-	} catch(e) {
-		console.error(e)
-	} finally {
-		if (conn) conn.release() //release to pool
-	}
-	return false
 }

--- a/backend/src/types/networkingTypes.ts
+++ b/backend/src/types/networkingTypes.ts
@@ -1,0 +1,70 @@
+
+import * as funtypes from 'funtypes'
+
+export type LoginInformation = funtypes.Static<typeof LoginInformation>
+export const LoginInformation = funtypes.ReadonlyObject({
+	userId: funtypes.String,
+	accountName: funtypes.String,
+	vantaaFMLoginToken: funtypes.String,
+})
+
+export type LoginSuccess = funtypes.Static<typeof LoginSuccess>
+export const LoginSuccess = funtypes.ReadonlyObject({
+	status: funtypes.Literal(200),
+	success: funtypes.Literal(true),
+	message: funtypes.Literal("Login success"),
+	data: LoginInformation,
+})
+
+export type CreateAccountSuccess = funtypes.Static<typeof CreateAccountSuccess>
+export const CreateAccountSuccess = funtypes.ReadonlyObject({
+	status: funtypes.Literal(200),
+	success: funtypes.Literal(true),
+	message: funtypes.Literal("Account created succesfully"),
+	data: LoginInformation,
+})
+
+export type CreateAccountFailure = funtypes.Static<typeof CreateAccountFailure>
+export const CreateAccountFailure = funtypes.ReadonlyObject({
+	status: funtypes.Literal(400),
+	success: funtypes.Literal(false),
+	message: funtypes.Literal("Failed to create account"),
+	data: funtypes.Object({
+		accountName: funtypes.String,
+	})
+})
+
+export type CreateAccountError = funtypes.Static<typeof CreateAccountError>
+export const CreateAccountError = funtypes.ReadonlyObject({
+	status: funtypes.Literal(400),
+	success: funtypes.Literal(false),
+	message: funtypes.Literal("Encountered an error on create account"),
+	error: funtypes.String,
+})
+
+export type LoginFailure = funtypes.Static<typeof LoginFailure>
+export const LoginFailure = funtypes.ReadonlyObject({
+	status: funtypes.Literal(400),
+	success: funtypes.Literal(false),
+	message: funtypes.Literal("Failed to login"),
+	data: funtypes.Object({
+		accountName: funtypes.String,
+	})
+})
+
+export type LoginError = funtypes.Static<typeof LoginError>
+export const LoginError = funtypes.ReadonlyObject({
+	status: funtypes.Literal(400),
+	success: funtypes.Literal(false),
+	message: funtypes.Literal("Encountered an error on login"),
+	error: funtypes.String,
+})
+
+export type LoginMessage = funtypes.Static<typeof LoginMessage>
+export const LoginMessage = funtypes.Union(LoginSuccess, LoginFailure, LoginError)
+
+export type CreateAccountMessage = funtypes.Static<typeof CreateAccountMessage>
+export const CreateAccountMessage = funtypes.Union(CreateAccountSuccess, CreateAccountFailure, CreateAccountError)
+
+export type NetworkingMessage = funtypes.Static<typeof NetworkingMessage>
+export const NetworkingMessage = funtypes.Union(LoginMessage, CreateAccountMessage)

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -20,6 +20,7 @@
         "@types/node": "^16.18.70",
         "@types/react": "^18.2.47",
         "@types/react-dom": "^18.2.18",
+        "funtypes": "5.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.21.2",
@@ -9026,6 +9027,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/funtypes": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/funtypes/-/funtypes-5.1.0.tgz",
+      "integrity": "sha512-Dg5o5JurgX53F/mTwYnFvV2Y95VZLuXw9emaAGSHnssoWxHciO0ZPwY9TPl2aSqU/LfYfCUHPfw7+1pRZvmqdw=="
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -15,6 +15,7 @@
     "@types/node": "^16.18.70",
     "@types/react": "^18.2.47",
     "@types/react-dom": "^18.2.18",
+    "funtypes": "5.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.21.2",

--- a/webapp/src/components/login/createAccountForm.tsx
+++ b/webapp/src/components/login/createAccountForm.tsx
@@ -1,16 +1,29 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { Grid,Paper, Avatar, TextField, Button, Typography,Link } from '@mui/material'
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined'
 import FormControlLabel from '@mui/material/FormControlLabel'
 import Checkbox from '@mui/material/Checkbox'
-import { sendCreateAccount, sendLogin } from './login'
+import { sendAndSaveCreateAccount } from './login'
+import { CreateAccountMessage } from '../../types/networkingTypes'
+
+const CreateAccountState = (param: { createAccountMessage: CreateAccountMessage | undefined} ) => {
+	if (param.createAccountMessage === undefined) return <></>
+	if (param.createAccountMessage.success === false) {
+		console.log(param.createAccountMessage)
+		return <p style = { { color: 'red' } }> { param.createAccountMessage.message } </p>
+	}
+	return <p style = { { color: 'green' } }> { `Account craeted and logged in as ${ param.createAccountMessage.data.accountName }` } </p>
+}
 
 const CreateAccountForm=()=>{
-	const [account, setAccount] = useState<string>("")
-	const [password, setPassword] = useState<string>("")
-	const paperStyle={padding :20,height:'70vh',width:280, margin:"20px auto"}
+	const [account, setAccount] = useState<string>('')
+	const [password, setPassword] = useState<string>('')
+	const [loginMessage, setLoginMessage] = useState<CreateAccountMessage | undefined>(undefined)
+	const paperStyle={padding :20,height:'70vh',width:280, margin:'20px auto'}
 	const avatarStyle={backgroundColor:'#1bbd7e'}
 	const btnstyle={margin:'8px 0'}
+
+	const createAccount = async () => setLoginMessage(await sendAndSaveCreateAccount(account, password))
 	return(
 		<Grid>
 			<Paper elevation={10} style={paperStyle}>
@@ -18,23 +31,24 @@ const CreateAccountForm=()=>{
 					 <Avatar style={avatarStyle}><LockOutlinedIcon/></Avatar>
 					<h2>Create Account</h2>
 				</Grid>
-				<TextField label='Username' placeholder='Enter username' variant="outlined" fullWidth required onChange={(e) => { setAccount(e.target.value) }}/>
-				<TextField label='Password' placeholder='Enter password' type='password' variant="outlined" fullWidth required onChange={(e) => { setPassword(e.target.value) }}/>
+				<TextField label='Username' placeholder='Enter username' variant='outlined' fullWidth required onChange={(e) => { setAccount(e.target.value) }}/>
+				<TextField label='Password' placeholder='Enter password' type='password' variant='outlined' fullWidth required onChange={(e) => { setPassword(e.target.value) }}/>
 				<FormControlLabel
 					control={
 					<Checkbox
-						name="checkedB"
-						color="primary"
+						name='checkedB'
+						color='primary'
 					/>
 					}
-					label="Remember me"
+					label='Remember me'
 				 />
-				<Button type='submit' onClick = { () => sendCreateAccount(account, password) } color='primary' variant="contained" style={btnstyle} fullWidth>Create Account</Button>
+				<Button type='submit' onClick = { createAccount } color='primary' variant='contained' style={btnstyle} fullWidth>Create Account</Button>
 				<Typography > Do you have an account ?
-					 <Link href="/login" >
+					 <Link href='/login' >
 						Sign Up 
 					</Link>
 				</Typography>
+				<CreateAccountState createAccountMessage = { loginMessage }/>
 			</Paper>
 		</Grid>
 	)

--- a/webapp/src/components/login/login.ts
+++ b/webapp/src/components/login/login.ts
@@ -1,39 +1,83 @@
+import { getLoginInformation, saveLoginInformation } from '../../helpers/localStorage'
+import { CreateAccountMessage, LoginMessage } from '../../types/networkingTypes'
+
 async function digestMessage(message: string) {
 	const msgUint8 = new TextEncoder().encode(message)
-	const hashBuffer = await crypto.subtle.digest("SHA-256", msgUint8)
+	const hashBuffer = await crypto.subtle.digest('SHA-256', msgUint8)
 	const hashArray = Array.from(new Uint8Array(hashBuffer))
-	const hashHex = hashArray.map((b) => b.toString(16).padStart(2, "0")).join("")
+	const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
 	return hashHex
 }
 
 const getPasswordHashWithSalt = async (password: string) => digestMessage(`VantaaFMSalt|${ password }`)
 
-export const sendLogin = async (accountName: string, password: string) => {
-	const response = await fetch('http://localhost:3000/auth/login', {
-		method: 'POST',
-		body: JSON.stringify({
-			accountName,
-			passwordHash: await getPasswordHashWithSalt(password)
-		}),
-		headers: {
-			'Content-Type': 'application/json;charset=UTF-8'
+export const sendAndSaveLogin = async (accountName: string, password: string): Promise<LoginMessage> => {
+	try {
+		const response = await fetch('http://localhost:3000/auth/login', {
+			method: 'POST',
+			body: JSON.stringify({
+				accountName,
+				passwordHash: await getPasswordHashWithSalt(password)
+			}),
+			headers: {
+				'Content-Type': 'application/json;charset=UTF-8'
+			}
+		})
+		const loginMessage = LoginMessage.parse(JSON.parse(await response.text()))
+		if (loginMessage.success) saveLoginInformation(loginMessage.data)
+		return loginMessage
+	} catch(error: unknown) {
+		console.error(error)
+		return {
+			status: 400,
+			success: false,
+			message: 'Encountered an error on login',
+			error: error instanceof Error ? error.toString() : 'Unknown error',
 		}
-	})
-	const responseText = await response.text()
-	console.log(responseText)
+	}
 }
 
-export const sendCreateAccount = async (accountName: string, password: string) => {
-	const response = await fetch('http://localhost:3000/auth/createAccount', {
-		method: 'POST',
-		body: JSON.stringify({
-			accountName: accountName,
-			passwordHash: await getPasswordHashWithSalt(password)
-		}),
-		headers: {
-			'Content-Type': 'application/json;charset=UTF-8'
+export const sendAndSaveCreateAccount = async (accountName: string, password: string): Promise<CreateAccountMessage> => {
+	try {
+		const response = await fetch('http://localhost:3000/auth/createAccount', {
+			method: 'POST',
+			body: JSON.stringify({
+				accountName: accountName,
+				passwordHash: await getPasswordHashWithSalt(password)
+			}),
+			headers: {
+				'Content-Type': 'application/json;charset=UTF-8'
+			}
+		})
+		const createAccountMessage = CreateAccountMessage.parse(JSON.parse(await response.text()))
+		if (createAccountMessage.success) saveLoginInformation(createAccountMessage.data)
+		return createAccountMessage
+	} catch(error: unknown) {
+		console.error(error)
+		return {
+			status: 400,
+			success: false,
+			message: 'Encountered an error on create account',
+			error: error instanceof Error ? error.toString() : 'Unknown error',
 		}
-	})
-	const responseText = await response.text()
-	console.log(responseText)
+	}
+}
+
+export const sendTestJwtToken = async () => {
+	const data = getLoginInformation()
+	if (data === undefined) return console.error('No Login data!')
+	try {
+		const response = await fetch('http://localhost:3000/auth/testToken', {
+			method: 'POST',
+			body: JSON.stringify({
+				vantaaFMLoginToken: data.vantaaFMLoginToken,
+			}),
+			headers: {
+				'Content-Type': 'application/json;charset=UTF-8'
+			}
+		})
+		console.log(response)
+	} catch(error: unknown) {
+		console.error(error)
+	}
 }

--- a/webapp/src/components/login/loginform.tsx
+++ b/webapp/src/components/login/loginform.tsx
@@ -1,16 +1,33 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { Grid,Paper, Avatar, TextField, Button, Typography,Link } from '@mui/material'
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined'
 import FormControlLabel from '@mui/material/FormControlLabel'
 import Checkbox from '@mui/material/Checkbox'
-import { sendCreateAccount, sendLogin } from './login'
+import { sendAndSaveLogin, sendTestJwtToken } from './login'
+import { LoginMessage } from '../../types/networkingTypes'
 
-const LoginForm=()=>{
-	const [account, setAccount] = useState<string>("")
-	const [password, setPassword] = useState<string>("")
-	const paperStyle={padding :20,height:'70vh',width:280, margin:"20px auto"}
+const LoginState = (param: { loginMessage: LoginMessage | undefined} ) => {
+	if (param.loginMessage === undefined) return <></>
+	if (param.loginMessage.success === false) {
+		console.log(param.loginMessage)
+		return <p style = { { color: 'red' } }> { param.loginMessage.message } </p>
+	}
+	return <>
+		<p style = { { color: 'green' } }> { `Logged in as ${ param.loginMessage.data.accountName }` } </p>
+		<Button type='submit' onClick = { sendTestJwtToken } fullWidth>Test token</Button>
+	</>
+}
+
+const LoginForm = () => {
+	const [account, setAccount] = useState<string>('')
+	const [password, setPassword] = useState<string>('')
+	const [loginMessage, setLoginMessage] = useState<LoginMessage | undefined>(undefined)
+	const paperStyle={padding :20,height:'70vh',width:280, margin:'20px auto'}
 	const avatarStyle={backgroundColor:'#1bbd7e'}
 	const btnstyle={margin:'8px 0'}
+
+	const login = async () => setLoginMessage(await sendAndSaveLogin(account, password))
+
 	return(
 		<Grid>
 			<Paper elevation={10} style={paperStyle}>
@@ -18,23 +35,24 @@ const LoginForm=()=>{
 					 <Avatar style={avatarStyle}><LockOutlinedIcon/></Avatar>
 					<h2>Login</h2>
 				</Grid>
-				<TextField label='Username' placeholder='Enter username' variant="outlined" fullWidth required onChange={(e) => { setAccount(e.target.value) }}/>
-				<TextField label='Password' placeholder='Enter password' type='password' variant="outlined" fullWidth required onChange={(e) => { setPassword(e.target.value) }}/>
+				<TextField label='Username' placeholder='Enter username' variant='outlined' fullWidth required onChange={(e) => { setAccount(e.target.value) }}/>
+				<TextField label='Password' placeholder='Enter password' type='password' variant='outlined' fullWidth required onChange={(e) => { setPassword(e.target.value) }}/>
 				<FormControlLabel
 					control={
 					<Checkbox
-						name="checkedB"
-						color="primary"
+						name='checkedB'
+						color='primary'
 					/>
 					}
-					label="Remember me"
+					label='Remember me'
 				 />
-				<Button type='submit' onClick = { () => sendLogin(account, password) } color='primary' variant="contained" style={btnstyle} fullWidth>Sign in</Button>
+				<Button type='submit' onClick = { login } color='primary' variant='contained' style={btnstyle} fullWidth>Sign in</Button>
 				<Typography > Don't have an account?
-					 <Link href="/createAccount" >
+					 <Link href='/createAccount' >
 						Create Account
 					</Link>
 				</Typography>
+				<LoginState loginMessage = { loginMessage }/>
 			</Paper>
 		</Grid>
 	)

--- a/webapp/src/helpers/localStorage.ts
+++ b/webapp/src/helpers/localStorage.ts
@@ -1,0 +1,13 @@
+
+import { LoginInformation } from '../types/networkingTypes'
+
+const loginInformationStorageKey = 'loginInformation'
+export const saveLoginInformation = (info: LoginInformation) => {
+	window.localStorage.setItem(loginInformationStorageKey, JSON.stringify(LoginInformation.serialize(info)))
+}
+
+export const getLoginInformation = () => {
+	const info = window.localStorage.getItem(loginInformationStorageKey)
+	if (info === null) return undefined
+	return LoginInformation.parse(JSON.parse(info))
+}

--- a/webapp/src/types/networkingTypes.ts
+++ b/webapp/src/types/networkingTypes.ts
@@ -1,0 +1,70 @@
+
+import * as funtypes from 'funtypes'
+
+export type LoginInformation = funtypes.Static<typeof LoginInformation>
+export const LoginInformation = funtypes.ReadonlyObject({
+	userId: funtypes.String,
+	accountName: funtypes.String,
+	vantaaFMLoginToken: funtypes.String,
+})
+
+export type LoginSuccess = funtypes.Static<typeof LoginSuccess>
+export const LoginSuccess = funtypes.ReadonlyObject({
+	status: funtypes.Literal(200),
+	success: funtypes.Literal(true),
+	message: funtypes.Literal("Login success"),
+	data: LoginInformation,
+})
+
+export type CreateAccountSuccess = funtypes.Static<typeof CreateAccountSuccess>
+export const CreateAccountSuccess = funtypes.ReadonlyObject({
+	status: funtypes.Literal(200),
+	success: funtypes.Literal(true),
+	message: funtypes.Literal("Account created succesfully"),
+	data: LoginInformation,
+})
+
+export type CreateAccountFailure = funtypes.Static<typeof CreateAccountFailure>
+export const CreateAccountFailure = funtypes.ReadonlyObject({
+	status: funtypes.Literal(400),
+	success: funtypes.Literal(false),
+	message: funtypes.Literal("Failed to create account"),
+	data: funtypes.Object({
+		accountName: funtypes.String,
+	})
+})
+
+export type CreateAccountError = funtypes.Static<typeof CreateAccountError>
+export const CreateAccountError = funtypes.ReadonlyObject({
+	status: funtypes.Literal(400),
+	success: funtypes.Literal(false),
+	message: funtypes.Literal("Encountered an error on create account"),
+	error: funtypes.String,
+})
+
+export type LoginFailure = funtypes.Static<typeof LoginFailure>
+export const LoginFailure = funtypes.ReadonlyObject({
+	status: funtypes.Literal(400),
+	success: funtypes.Literal(false),
+	message: funtypes.Literal("Failed to login"),
+	data: funtypes.Object({
+		accountName: funtypes.String,
+	})
+})
+
+export type LoginError = funtypes.Static<typeof LoginError>
+export const LoginError = funtypes.ReadonlyObject({
+	status: funtypes.Literal(400),
+	success: funtypes.Literal(false),
+	message: funtypes.Literal("Encountered an error on login"),
+	error: funtypes.String,
+})
+
+export type LoginMessage = funtypes.Static<typeof LoginMessage>
+export const LoginMessage = funtypes.Union(LoginSuccess, LoginFailure, LoginError)
+
+export type CreateAccountMessage = funtypes.Static<typeof CreateAccountMessage>
+export const CreateAccountMessage = funtypes.Union(CreateAccountSuccess, CreateAccountFailure, CreateAccountError)
+
+export type NetworkingMessage = funtypes.Static<typeof NetworkingMessage>
+export const NetworkingMessage = funtypes.Union(LoginMessage, CreateAccountMessage)


### PR DESCRIPTION
Now you can input to create account form and create account to backend. This will result in create account message on frontend. You can then login to the application on login form with the account / password, this will result in login message in frontend.

When logged in with login form, you can also send testJWT token message that will print the token information on backend (not visible on frontend).

I also added functions to set Spotify token and retrieve it.

The login information is stored to local storage on client, but this does not auto login you in at the moment, this is still todo.